### PR TITLE
fix resolve collision bug when serviceNames have the same prefix

### DIFF
--- a/common.go
+++ b/common.go
@@ -14,17 +14,19 @@
 
 package etcd
 
+import "fmt"
+
 const (
-	etcdPrefix = "kitex/registry-etcd"
+	etcdPrefixTpl = "kitex/registry-etcd/%v/"
 )
 
 func serviceKeyPrefix(serviceName string) string {
-	return etcdPrefix + "/" + serviceName
+	return fmt.Sprintf(etcdPrefixTpl, serviceName)
 }
 
 // serviceKey generates the key used to stored in etcd.
 func serviceKey(serviceName, addr string) string {
-	return serviceKeyPrefix(serviceName) + "/" + addr
+	return serviceKeyPrefix(serviceName) + addr
 }
 
 // instanceInfo used to stored service basic info in etcd.

--- a/etcd_registry.go
+++ b/etcd_registry.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cloudwego/kitex/pkg/klog"
@@ -45,7 +46,7 @@ type registerMeta struct {
 	cancel  context.CancelFunc
 }
 
-// NewEtcdRegistry creates a etcd based registry.
+// NewEtcdRegistry creates an etcd based registry.
 func NewEtcdRegistry(endpoints []string, opts ...Option) (registry.Registry, error) {
 	cfg := clientv3.Config{
 		Endpoints: endpoints,
@@ -172,6 +173,9 @@ func (e *etcdRegistry) keepalive(meta *registerMeta) error {
 func validateRegistryInfo(info *registry.Info) error {
 	if info.ServiceName == "" {
 		return fmt.Errorf("missing service name in Register")
+	}
+	if strings.Contains(info.ServiceName, "/") {
+		return fmt.Errorf("service name registered with etcd should not include character '/'")
 	}
 	if info.Addr == nil {
 		return fmt.Errorf("missing addr in Register")

--- a/etcd_resolver_test.go
+++ b/etcd_resolver_test.go
@@ -147,6 +147,32 @@ func TestEtcdResolverWithSamePrefix(t *testing.T) {
 	teardownEmbedEtcd(s)
 }
 
+func TestEtcdRegistryWithSamePrefix(t *testing.T) {
+	s, endpoint := setupEmbedEtcd(t)
+
+	rg, err := NewEtcdRegistry([]string{endpoint})
+	require.Nil(t, err)
+
+	infoList := []registry.Info{
+		{
+			ServiceName: "registry-etcd/test",
+			Addr:        utils.NewNetAddr("tcp", "127.0.0.1:8888"),
+			Weight:      66,
+			Tags:        map[string]string{"hello": "world"},
+		},
+	}
+
+	// test register service
+	{
+		for _, info := range infoList {
+			err = rg.Register(&info)
+			require.NotNil(t, err)
+		}
+	}
+
+	teardownEmbedEtcd(s)
+}
+
 func TestEmptyEndpoints(t *testing.T) {
 	_, err := NewEtcdResolver([]string{})
 	require.NotNil(t, err)

--- a/etcd_resolver_test.go
+++ b/etcd_resolver_test.go
@@ -317,13 +317,13 @@ func setupCertificate() (caFile, certFile, keyFile string, err error) {
 
 	// pem encode
 	caPEM := new(bytes.Buffer)
-	pem.Encode(caPEM, &pem.Block{
+	_ = pem.Encode(caPEM, &pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: caBytes,
 	})
 
 	caPrivKeyPEM := new(bytes.Buffer)
-	pem.Encode(caPrivKeyPEM, &pem.Block{
+	_ = pem.Encode(caPrivKeyPEM, &pem.Block{
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(caPrivKey),
 	})
@@ -356,13 +356,13 @@ func setupCertificate() (caFile, certFile, keyFile string, err error) {
 	}
 
 	certPEM := new(bytes.Buffer)
-	pem.Encode(certPEM, &pem.Block{
+	_ = pem.Encode(certPEM, &pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: certBytes,
 	})
 
 	certPrivKeyPEM := new(bytes.Buffer)
-	pem.Encode(certPrivKeyPEM, &pem.Block{
+	_ = pem.Encode(certPrivKeyPEM, &pem.Block{
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(certPrivKey),
 	})


### PR DESCRIPTION
kitex-contrib/registry-etcd in current version facing at the bug that services will be resolved chaotically when services have names with the same prefix.
For example, 
Service A named "demo-service"
Service B named "demo-service-B"
the resolver will return both Service A and Service B registry info when resolve for "demo-service".