### PR TITLE
feat: support setting default weight

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,47 @@ func main() {
 }
 ```
 
+## Default Weight
+
+The weighted load balancing algorithm can only handle positive weights, and will be filtered when the weight is if 0 or negative. Setting default weights can avoid filtering.
+
+### Default Config
+
+| Config Name       | Default Value | Description                                                                                                                          |
+|:------------------|:--------------|:-------------------------------------------------------------------------------------------------------------------------------------|
+| WithDefaultWeight | 10            | Used to set the default wight of instances, if 0 or negative, it means instances with 0 or negative weight will be filtered          |
+
+### Example
+
+```go
+package main
+
+import (
+	...
+    "github.com/cloudwego/kitex/client"
+    etcd "github.com/kitex-contrib/registry-etcd"
+)
+
+func main() {
+	// creates a etcd based resolver with default weight
+	r, err := etcd.NewEtcdResolver([]string{"127.0.0.1:2379"}, etcd.WithDefaultWeight(10))
+	if err != nil {
+		log.Fatal(err)
+	}
+	client := hello.MustNewClient("Hello", client.WithResolver(r))
+	for {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+		resp, err := client.Echo(ctx, &api.Request{Message: "Hello"})
+		cancel()
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Println(resp)
+		time.Sleep(time.Second)
+	}
+}
+```
+
 ## How to Dynamically specify ip and port
 To dynamically specify an IP and port, one should first set the environment variables KITEX_IP_TO_REGISTRY and KITEX_PORT_TO_REGISTRY. If these variables are not set, the system defaults to using the service's listening IP and port. Notably, if the service's listening IP is either not set or set to "::", the system will automatically retrieve and use the machine's IPV4 address.
 

--- a/option.go
+++ b/option.go
@@ -18,18 +18,20 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"github.com/cloudwego/kitex/pkg/klog"
-	clientv3 "go.etcd.io/etcd/client/v3"
 	"io/ioutil" //nolint
 	"time"
+
+	"github.com/cloudwego/kitex/pkg/klog"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 // Option sets options such as username, tls etc.
 type Option func(cfg *Config)
 
 type Config struct {
-	EtcdConfig *clientv3.Config
-	Prefix     string
+	EtcdConfig    *clientv3.Config
+	Prefix        string
+	DefaultWeight int
 }
 
 // WithTLSOpt returns a option that authentication by tls/ssl.
@@ -83,5 +85,12 @@ func newTLSConfig(certFile, keyFile, caFile, serverName string) (*tls.Config, er
 func WithEtcdServicePrefix(prefix string) Option {
 	return func(c *Config) {
 		c.Prefix = prefix
+	}
+}
+
+// WithDefaultWeight returns an option that sets the DefaultWeight field in the Config struct
+func WithDefaultWeight(defaultWeight int) Option {
+	return func(cfg *Config) {
+		cfg.DefaultWeight = defaultWeight
 	}
 }


### PR DESCRIPTION
The weighted load balancing algorithm can only handle positive weights, and will be filtered when the weight is 0 or negative. Setting default weights can avoid filtering.

At the same time, the current default value is hard-coded 10, which will not be possible when the user wants to take the instance offline via the control plane.

see https://github.com/cloudwego/kitex/issues/1393