### PR TITLE
fix: fix etcd registry keepalive reconnection and context leak

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: '1.23.x'
 
       - name: Golangci Lint
         # https://golangci-lint.run/

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -30,3 +30,4 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: latest
+          args: --timeout=5m

--- a/etcd_registry.go
+++ b/etcd_registry.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/cloudwego/kitex/pkg/klog"
@@ -41,7 +42,7 @@ const (
 type etcdRegistry struct {
 	etcdClient  *clientv3.Client
 	leaseTTL    int64
-	meta        *registerMeta
+	meta        atomic.Pointer[registerMeta]
 	retryConfig *retry.Config
 	stop        chan struct{}
 	address     net.Addr
@@ -153,7 +154,7 @@ func (e *etcdRegistry) Register(info *registry.Info) error {
 	if err := e.keepalive(&meta); err != nil {
 		return err
 	}
-	e.meta = &meta
+	e.meta.Store(&meta)
 	return nil
 }
 
@@ -165,7 +166,10 @@ func (e *etcdRegistry) Deregister(info *registry.Info) error {
 	if err := e.deregister(info); err != nil {
 		return err
 	}
-	e.meta.cancel()
+	m := e.meta.Load()
+	if m != nil && m.cancel != nil {
+		m.cancel()
+	}
 	return nil
 }
 
@@ -205,7 +209,7 @@ func (e *etcdRegistry) register(info *registry.Info, leaseID clientv3.LeaseID) e
 // keepRegister keep service registered status
 // maxRetry == 0 means retry forever
 func (e *etcdRegistry) keepRegister(key, val string, retryConfig *retry.Config) {
-	var failedTimes uint = 0
+	var failedTimes uint
 	delay := retryConfig.ObserveDelay
 	for retryConfig.MaxAttemptTimes == 0 || failedTimes < retryConfig.MaxAttemptTimes {
 		select {
@@ -255,10 +259,11 @@ func (e *etcdRegistry) keepRegister(key, val string, retryConfig *retry.Config) 
 					failedTimes++
 					return
 				}
-				if e.meta != nil && e.meta.cancel != nil {
-					e.meta.cancel()
+				m := e.meta.Load()
+				if m != nil && m.cancel != nil {
+					m.cancel()
 				}
-				e.meta = &meta
+				e.meta.Store(&meta)
 				delay = retryConfig.ObserveDelay
 			}
 			failedTimes = 0
@@ -293,20 +298,14 @@ func (e *etcdRegistry) grantLease() (clientv3.LeaseID, error) {
 }
 
 func (e *etcdRegistry) keepalive(meta *registerMeta) error {
+	keepAlive, err := e.etcdClient.KeepAlive(meta.ctx, meta.leaseID)
+	if err != nil {
+		return err
+	}
+
 	go func() {
+		klog.Infof("start keepalive lease %x for etcd registry", meta.leaseID)
 		for {
-			select {
-			case <-meta.ctx.Done():
-				klog.Infof("stop keepalive lease %x for etcd registry", meta.leaseID)
-				return
-			default:
-			}
-			keepAlive, err := e.etcdClient.KeepAlive(meta.ctx, meta.leaseID)
-			if err != nil {
-				klog.Warnf("keepalive lease %x for etcd registry failed with err: %v", meta.leaseID, err)
-				time.Sleep(time.Second * 2)
-				continue
-			}
 			for range keepAlive {
 				select {
 				case <-meta.ctx.Done():
@@ -316,7 +315,20 @@ func (e *etcdRegistry) keepalive(meta *registerMeta) error {
 				}
 			}
 			klog.Warnf("keepalive channel closed for lease %x for etcd registry", meta.leaseID)
-			time.Sleep(time.Second * 2)
+
+			for {
+				select {
+				case <-meta.ctx.Done():
+					klog.Infof("stop keepalive lease %x for etcd registry", meta.leaseID)
+					return
+				case <-time.After(time.Second * 2):
+				}
+				keepAlive, err = e.etcdClient.KeepAlive(meta.ctx, meta.leaseID)
+				if err == nil {
+					break
+				}
+				klog.Warnf("retry keepalive lease %x failed with err: %v", meta.leaseID, err)
+			}
 		}
 	}()
 	return nil

--- a/etcd_registry.go
+++ b/etcd_registry.go
@@ -264,7 +264,7 @@ func (e *etcdRegistry) keepRegister(key, val string, retryConfig *retry.Config) 
 				oldMeta := e.meta.Load()
 				if oldMeta == &closeMeta {
 					meta.cancel()
-					break
+					return
 				}
 				if e.meta.CompareAndSwap(oldMeta, &meta) {
 					if oldMeta != nil && oldMeta.cancel != nil {

--- a/etcd_registry.go
+++ b/etcd_registry.go
@@ -306,12 +306,16 @@ func (e *etcdRegistry) keepalive(meta *registerMeta) error {
 	go func() {
 		klog.Infof("start keepalive lease %x for etcd registry", meta.leaseID)
 		for {
-			for range keepAlive {
+			channelClosed := false
+			for !channelClosed {
 				select {
 				case <-meta.ctx.Done():
 					klog.Infof("stop keepalive lease %x for etcd registry", meta.leaseID)
 					return
-				default:
+				case _, ok := <-keepAlive:
+					if !ok {
+						channelClosed = true
+					}
 				}
 			}
 			klog.Warnf("keepalive channel closed for lease %x for etcd registry", meta.leaseID)

--- a/etcd_registry.go
+++ b/etcd_registry.go
@@ -205,7 +205,7 @@ func (e *etcdRegistry) register(info *registry.Info, leaseID clientv3.LeaseID) e
 // keepRegister keep service registered status
 // maxRetry == 0 means retry forever
 func (e *etcdRegistry) keepRegister(key, val string, retryConfig *retry.Config) {
-	var failedTimes uint
+	var failedTimes uint = 0
 	delay := retryConfig.ObserveDelay
 	for retryConfig.MaxAttemptTimes == 0 || failedTimes < retryConfig.MaxAttemptTimes {
 		select {
@@ -218,48 +218,51 @@ func (e *etcdRegistry) keepRegister(key, val string, retryConfig *retry.Config) 
 		case <-time.After(delay):
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
-		defer cancel()
-		resp, err := e.etcdClient.Get(ctx, key)
-		if err != nil {
-			klog.Warnf("keep register get %s failed with err: %v", key, err)
-			delay = retryConfig.RetryDelay
-			failedTimes++
-			continue
-		}
-
-		if len(resp.Kvs) == 0 {
-			klog.Infof("keep register service %s", key)
-			delay = retryConfig.RetryDelay
-			leaseID, err := e.grantLease()
+		func() {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+			defer cancel()
+			resp, err := e.etcdClient.Get(ctx, key)
 			if err != nil {
-				klog.Warnf("keep register grant lease %s failed with err: %v", key, err)
+				klog.Warnf("keep register get %s failed with err: %v", key, err)
+				delay = retryConfig.RetryDelay
 				failedTimes++
-				continue
+				return
 			}
 
-			_, err = e.etcdClient.Put(ctx, key, val, clientv3.WithLease(leaseID))
-			if err != nil {
-				klog.Warnf("keep register put %s failed with err: %v", key, err)
-				failedTimes++
-				continue
-			}
+			if len(resp.Kvs) == 0 {
+				klog.Infof("keep register service %s", key)
+				delay = retryConfig.RetryDelay
+				leaseID, err := e.grantLease()
+				if err != nil {
+					klog.Warnf("keep register grant lease %s failed with err: %v", key, err)
+					failedTimes++
+					return
+				}
 
-			meta := registerMeta{
-				leaseID: leaseID,
-			}
-			meta.ctx, meta.cancel = context.WithCancel(context.Background())
-			if err := e.keepalive(&meta); err != nil {
-				klog.Warnf("keep register keepalive %s failed with err: %v", key, err)
-				failedTimes++
-				continue
-			}
-			e.meta.cancel()
-			e.meta = &meta
-			delay = retryConfig.ObserveDelay
-		}
+				_, err = e.etcdClient.Put(ctx, key, val, clientv3.WithLease(leaseID))
+				if err != nil {
+					klog.Warnf("keep register put %s failed with err: %v", key, err)
+					failedTimes++
+					return
+				}
 
-		failedTimes = 0
+				meta := registerMeta{
+					leaseID: leaseID,
+				}
+				meta.ctx, meta.cancel = context.WithCancel(context.Background())
+				if err := e.keepalive(&meta); err != nil {
+					klog.Warnf("keep register keepalive %s failed with err: %v", key, err)
+					failedTimes++
+					return
+				}
+				if e.meta != nil && e.meta.cancel != nil {
+					e.meta.cancel()
+				}
+				e.meta = &meta
+				delay = retryConfig.ObserveDelay
+			}
+			failedTimes = 0
+		}()
 	}
 	klog.Errorf("keep register service %s failed times:%d", key, failedTimes)
 }
@@ -290,20 +293,30 @@ func (e *etcdRegistry) grantLease() (clientv3.LeaseID, error) {
 }
 
 func (e *etcdRegistry) keepalive(meta *registerMeta) error {
-	keepAlive, err := e.etcdClient.KeepAlive(meta.ctx, meta.leaseID)
-	if err != nil {
-		return err
-	}
 	go func() {
-		// eat keepAlive channel to keep related lease alive.
-		klog.Infof("start keepalive lease %x for etcd registry", meta.leaseID)
-		for range keepAlive {
+		for {
 			select {
 			case <-meta.ctx.Done():
 				klog.Infof("stop keepalive lease %x for etcd registry", meta.leaseID)
 				return
 			default:
 			}
+			keepAlive, err := e.etcdClient.KeepAlive(meta.ctx, meta.leaseID)
+			if err != nil {
+				klog.Warnf("keepalive lease %x for etcd registry failed with err: %v", meta.leaseID, err)
+				time.Sleep(time.Second * 2)
+				continue
+			}
+			for range keepAlive {
+				select {
+				case <-meta.ctx.Done():
+					klog.Infof("stop keepalive lease %x for etcd registry", meta.leaseID)
+					return
+				default:
+				}
+			}
+			klog.Warnf("keepalive channel closed for lease %x for etcd registry", meta.leaseID)
+			time.Sleep(time.Second * 2)
 		}
 	}()
 	return nil

--- a/etcd_registry.go
+++ b/etcd_registry.go
@@ -55,6 +55,8 @@ type registerMeta struct {
 	cancel  context.CancelFunc
 }
 
+var closeMeta registerMeta
+
 // NewEtcdRegistry creates an etcd based registry.
 func NewEtcdRegistry(endpoints []string, opts ...Option) (registry.Registry, error) {
 	cfg := &Config{
@@ -166,7 +168,7 @@ func (e *etcdRegistry) Deregister(info *registry.Info) error {
 	if err := e.deregister(info); err != nil {
 		return err
 	}
-	m := e.meta.Load()
+	m := e.meta.Swap(&closeMeta)
 	if m != nil && m.cancel != nil {
 		m.cancel()
 	}
@@ -259,11 +261,16 @@ func (e *etcdRegistry) keepRegister(key, val string, retryConfig *retry.Config) 
 					failedTimes++
 					return
 				}
-				m := e.meta.Load()
-				if m != nil && m.cancel != nil {
-					m.cancel()
+				oldMeta := e.meta.Load()
+				if oldMeta == &closeMeta {
+					meta.cancel()
+					break
 				}
-				e.meta.Store(&meta)
+				if e.meta.CompareAndSwap(oldMeta, &meta) {
+					if oldMeta != nil && oldMeta.cancel != nil {
+						oldMeta.cancel()
+					}
+				}
 				delay = retryConfig.ObserveDelay
 			}
 			failedTimes = 0


### PR DESCRIPTION
this pr do such thing
1. keepalive: wrap KeepAlive in a retry loop to re-establish the lease
   when the keepAlive channel is closed due to network issues. The
   original code would silently exit the goroutine, causing the lease
   to expire and the service to be removed from the registry after 60s.

2. keepRegister: wrap the for-loop body in an anonymous function so
   that defer cancel() is properly called at the end of each iteration.
   The original code placed defer cancel() directly in the for loop,
   causing context cancellation to be deferred until function return,
   resulting in context leaks on each retry.